### PR TITLE
Fix compile fail for fsosql.c

### DIFF
--- a/fs/client/fsosql.c
+++ b/fs/client/fsosql.c
@@ -677,7 +677,7 @@ SQLRETURN SQL_API SQLColAttribute(
 	SQLPOINTER CharacterAttributePtr,
 	SQLSMALLINT BufferLength,
 	SQLSMALLINT *StringLengthPtr,
-#ifdef _WIN64
+#if defined(_WIN64) || defined(Linux)
 	SQLLEN *NumericAttributePtr)
 #else
 	SQLPOINTER NumericAttributePtr)


### PR DESCRIPTION
Update fsosql.c to fix signature of SQLColAttribute to match sql.h on Ubuntu