### PR TITLE
Clean wipes out libcups.a

### DIFF
--- a/Makefile.dx.linux
+++ b/Makefile.dx.linux
@@ -71,7 +71,7 @@ EXECUTABLES:= dbcsql.so dbc dbcd dbcmp dbcsc
 all: $(EXECUTABLES)
 
 clean:
-	rm -f $(EXECUTABLES) *.o lib*.a
+	rm -f $(EXECUTABLES) *.o libdbc.a libjpeg.a libpng.a
 
 dbc: libdbc.a libjpeg.a libpng.a
 	$(CC) -o $@ $^ $(LDFLAGS) $(CUPSLIB) -lm $(SSLLIB) -ldl $(LCURSES)


### PR DESCRIPTION
Deleting *.a removes libcups.a which causes subsequent compilations to fail.  This change deletes the specific libraries that were built from the source compilation of DX.